### PR TITLE
Fix bad call to call_user_func_array

### DIFF
--- a/lib/Cake/Utility/Folder.php
+++ b/lib/Cake/Utility/Folder.php
@@ -226,10 +226,10 @@ class Folder {
 		}
 
 		if ($dirs) {
-			$dirs = call_user_func_array('array_merge', $dirs);
+			$dirs = call_user_func_array('array_merge', array_values($dirs));
 		}
 		if ($files) {
-			$files = call_user_func_array('array_merge', $files);
+			$files = call_user_func_array('array_merge', array_values($files));
 		}
 		return array($dirs, $files);
 	}


### PR DESCRIPTION
* PHP 8 now has named arguments.
* Passing unknown named arguments to internal functions causes a fatal `ArgumentCountError`.
* The array being passed to `call_user_func_array` in this pull request is an associative array of numeric arrays.
* In PHP < 8.0 this was benign, because PHP would ignore the key when passing the values to `array_merge`
* In PHP 8, the associative array is treated like a named argument, causing the fatal error.